### PR TITLE
Fix config

### DIFF
--- a/Receiver/Program.cs
+++ b/Receiver/Program.cs
@@ -15,10 +15,11 @@ namespace Receiver
 
         static async Task Start()
         {
-            var config = new EndpointConfiguration("WebApplication");
+            var config = new EndpointConfiguration("Receiver");
             var transport = config.UseTransport<RabbitMQTransport>();
             transport.ConnectionString("host=localhost");
             transport.UseConventionalRoutingTopology();
+            config.EnableInstallers();
 
             var persistence = config.UsePersistence<InMemoryPersistence>();
 

--- a/Sender/Program.cs
+++ b/Sender/Program.cs
@@ -50,10 +50,6 @@ namespace Sender
                 customizeConnectedInterface: configuration => { configuration.EnableMessageDrivenPublishSubscribe(storage); });
             connectorConfig.AutoCreateQueues();
 
-            //Configure where to send messages
-            connectorConfig.RouteToEndpoint(
-                messageType: typeof(MyMessage),
-                endpointName: "Samples.ASPNETCore.Endpoint");
 
             //Start the connector
             var connector = connectorConfig.CreateConnector();


### PR DESCRIPTION
The first commit removes the not needed routing configuration. That configuration would be needed if the message was sent, not published.

The second commit changes the receivers endpoint name. It can't be named the same as the connector in the sender because in that case the message goes into circles because the connector and the receiving endpoint read from the same queue. 